### PR TITLE
Update information around dangerous goods acceptance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,3 @@ DEPENDENCIES
   rake (~> 10.4.2)
   redcarpet (~> 3.3.2)
   rouge (~> 1.9.0)
-
-BUNDLED WITH
-   1.10.6

--- a/source/includes/_create_orders.md
+++ b/source/includes/_create_orders.md
@@ -15,7 +15,6 @@ To create an order, submit order data via POST command. The order will be reject
   -d '{
     "pickup_date": "2015-11-24",
     "description": "Kryptonite",
-    "confirmed_not_dangerous": true,
     "kilogram_weight": 1,
     "cubic_metre_volume": 0.01,
     "customer_reference": "SupBdayPressie",
@@ -72,7 +71,6 @@ Each collection within the example booking JSON is described in detail in the se
   {
     "pickup_date": "2015-11-24",
     "description": "Kryptonite",
-    "confirmed_not_dangerous": true,
     "kilogram_weight": 1,
     "cubic_metre_volume": 0.01,
     "customer_reference": "SupBdayPressie"
@@ -83,7 +81,6 @@ Each collection within the example booking JSON is described in detail in the se
 |-----------:|:-----------|
 **pickup_date** <div class="optional">"yyyy-mm-dd"</div>| Date must be at least one non-holiday, business day in the future.
 **description** <div class="optional">optional</div> | Description is used by the customer to track the parcel on Sendle Dashboard. It does not show up on a label.  It must be under 255 characters in length.
-**confirmed_not_dangerous** <div class="optional">boolean value</div> | Sendle will only make a booking if `confirmed_not_dangerous` is set to true.
 **kilogram_weight** | Must be a decimal value over zero and less than the category/max weight allowed (25kg max).
 **cubic_metre_volume** | Must be a decimal value above zero and less than one.  To get value, multiply *length* x *width* x *depth* of parcel in metres.
 **customer_reference** <div class="optional">optional</div> | Reference will appear on the label for parcel identification.  It must be under 255 characters in length.
@@ -196,7 +193,6 @@ Each collection within the example booking JSON is described in detail in the se
       "pickup_date":"2015-10-24"
     },
     "description":"Kryptonite",
-    "confirmed_not_dangerous":true,
     "kilogram_weight":"1.0",
     "cubic_metre_volume":"0.01",
     "customer_reference":"SupBdayPressie",

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -100,6 +100,24 @@ Without a [credit card on file](#set-up-payments), booking orders will respond w
 
 If an Order ID or label url is incorrectly entered, a `404` error will be returned. Double-check the ID or url before continuing.
 
+## 412 Precondition Failed
+
+> 412 Response after POST valid order
+
+```json
+  {
+    "error":"precondition_failed",
+    "error_description":"The account associated with this API key has not accepted the dangerous goods terms. Please visit https://www.sendle.com/ to view and accept terms."
+  }
+```
+
+*Dangerous goods terms have not been accepted*
+
+Without accepting [dangerous goods terms](#set-up-account), booking orders will respond with a `412` error.
+
+**Non-booking queries will continue to work without accepting dangerous goods terms and will not receive an error.**
+
+
 
 ## 422 Unprocessable Entity
 > Request with unallowable errors:

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -107,7 +107,7 @@ If an Order ID or label url is incorrectly entered, a `404` error will be return
 ```json
   {
     "error":"precondition_failed",
-    "error_description":"The account associated with this API key has not accepted the dangerous goods terms. Please visit https://www.sendle.com/ to view and accept terms."
+    "error_description":"The account associated with this API key has not accepted the dangerous goods terms. Please visit your Account Settings in https://www.sendle.com/dashboard/ to view and accept these terms."
   }
 ```
 

--- a/source/includes/_getting_started.md
+++ b/source/includes/_getting_started.md
@@ -29,6 +29,18 @@ Once you have been granted API access, visit your API tab to get your `api key`.
   {"error":"payment_required","error_description":"The account associated with this API key has no method of payment. Please go to your Account Settings in your Sendle Dashboard and add a payment method."}  
 ```
 
-To use the Sendle API, during the beta period you need to be on a manually invoiced account. Sendle Support will
-organise this for you.
+To use the Sendle API, during the beta period you need to attach a credit card to your Sendle account for invoicing.
 
+## Set Up Account
+
+> Response Without Dangerous Goods Terms Accepted
+
+```json
+  {
+    "error":"precondition_failed",
+    "error_description":"The account associated with this API key has not accepted the dangerous goods terms. Please visit https://www.sendle.com/ to view and accept terms."
+  }
+```
+
+To create orders with the Sendle API you must accept the dangerous goods
+terms in your `Account Settings`, under the `Pickup` tab.

--- a/source/includes/_getting_started.md
+++ b/source/includes/_getting_started.md
@@ -38,7 +38,7 @@ To use the Sendle API, during the beta period you need to attach a credit card t
 ```json
   {
     "error":"precondition_failed",
-    "error_description":"The account associated with this API key has not accepted the dangerous goods terms. Please visit https://www.sendle.com/ to view and accept terms."
+    "error_description":"The account associated with this API key has not accepted the dangerous goods terms. Please visit your Account Settings in https://www.sendle.com/dashboard/ to view and accept these terms."
   }
 ```
 


### PR DESCRIPTION
Remove requirement of `confirmed_not_dangerous` on a per order basis and provide information about setting it up on their account.