### PR TITLE
Be super clear about expected URL and http verb

### DIFF
--- a/source/includes/_cancelling_orders.md
+++ b/source/includes/_cancelling_orders.md
@@ -1,6 +1,6 @@
 # Cancelling Orders
-## `Delete /api/orders/{id}`
-> [ Delete /api/orders/{id} ]
+## `DELETE /api/orders/{id}`
+> [ DELETE /api/orders/{id} ]
 
 ```shell
   curl "https://www.sendle.com/api/orders/f5233746-71d4-4b05-bf63-56f4abaed5f6"

--- a/source/includes/_cancelling_orders.md
+++ b/source/includes/_cancelling_orders.md
@@ -1,6 +1,6 @@
 # Cancelling Orders
-
-> [ Delete /orders/{id} ]
+## `Delete /api/orders/{id}`
+> [ Delete /api/orders/{id} ]
 
 ```shell
   curl "https://www.sendle.com/api/orders/f5233746-71d4-4b05-bf63-56f4abaed5f6"
@@ -21,6 +21,7 @@
     "cancellation_message":"Cancelled by S6LRX64PV8MABbBbzu6DoBHD during picking up"
   }
 ```
+
 
 As long as an order has not been consigned with the courier, an order is cancellable. The value to review is:
 

--- a/source/includes/_create_orders.md
+++ b/source/includes/_create_orders.md
@@ -1,6 +1,7 @@
 # Creating Orders
+## `POST /api/orders`
 
-`POST /orders`
+> [ POST /api/orders ]
 
 To create an order, submit order data via POST command. The order will be rejected if the data fails validation and the API will respond with an error.
 

--- a/source/includes/_getting_labels.md
+++ b/source/includes/_getting_labels.md
@@ -1,7 +1,7 @@
 # Getting Labels
-## `GET /api/{label_url}`
+## `GET {label_url}`
 
-> [ GET /api/{label_url} ]
+> [ GET {label_url} ]
 
 ```shell
   curl "https://www.sendle.com/api/orders/f5233746-71d4-4b05-bf63-56f4abaed5f6/labels/a4.pdf"

--- a/source/includes/_getting_labels.md
+++ b/source/includes/_getting_labels.md
@@ -1,6 +1,7 @@
 # Getting Labels
+## `GET /api/{label_url}`
 
-> [ GET /label_url ]
+> [ GET /api/{label_url} ]
 
 ```shell
   curl "https://www.sendle.com/api/orders/f5233746-71d4-4b05-bf63-56f4abaed5f6/labels/a4.pdf"

--- a/source/includes/_getting_quotes.md
+++ b/source/includes/_getting_quotes.md
@@ -1,6 +1,7 @@
 # Getting Quotes
+## `GET /api/quote`
 
-`/api/quote`
+> [ GET /api/quote ]
 
 The quoting API does not require you to include your Sendle ID and API Key, but be sure to include all the relevant fields.
 

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -25,5 +25,5 @@ endpoint | request | task
 /api/quote | GET | [Quoting](#getting-quotes)
 /api/orders | POST | [Booking Orders](#creating-orders)
 /api/orders/{id} | GET | [View Order {id}](#view-an-order)
-/label_url | GET | [View a label](#getting-labels)
+/api/{label_url} | GET | [View a label](#getting-labels)
 /api/orders/{id} | DELETE | [Cancel an order](#cancelling-orders)

--- a/source/includes/_ping_server.md
+++ b/source/includes/_ping_server.md
@@ -1,4 +1,7 @@
 # Ping Server
+## `GET /api/ping`
+
+> [ GET /api/ping ]
 
 > All API interactions will require your Sendle ID and your API Key (Make sure to replace **sendleAPI** and **42RRTjYz5Z4hZrm8XY3t4Vxt** with your Sendle ID & API key.)
 

--- a/source/includes/_view_order.md
+++ b/source/includes/_view_order.md
@@ -1,4 +1,7 @@
 # View an Order
+## `GET /api/orders/{id}`
+
+> [ GET /api/orders/{id} ]
 
 ```shell
   curl "https://www.sendle.com/api/orders/f5233746-71d4-4b05-bf63-56f4abaed5f6"
@@ -70,9 +73,6 @@
     }
   } 
 ```
-
-
-`GET /api/orders/{id}`
 
 Viewing an order will give you all the details associated with an existing Sendle Booking. Important details in an order include:
 

--- a/source/includes/_view_order.md
+++ b/source/includes/_view_order.md
@@ -83,4 +83,4 @@ Viewing an order will give you all the details associated with an existing Sendl
 **order_url** | Specific url for order queries. After booking, this url becomes the point to check for updated information (state changes), labels and any other information related to the order.|
 **labels** | Covered in detail in the [label section](#getting-labels). This field returns `null` at the initial order booking. After the booking is processed, label details will be included here. |
 **scheduling** | Information regarding the order's pickup date and whether an order can be [cancelled](#cancelling-orders) |
- | Estimate Delivery range (minimum & Maximum). These dates can change depending on courier conditions.
+ | Estimate Delivery range (minimum & maximum). These dates can change depending on courier conditions.


### PR DESCRIPTION
We had it on some, but not all.

Now it's on the left and right hand side as a sub-header for every API endpoint - so it's always visible.