### PR TITLE
Clarity tweaks to API docs

### DIFF
--- a/source/includes/_cancelling_orders.md
+++ b/source/includes/_cancelling_orders.md
@@ -7,6 +7,7 @@
   -X DELETE
   -u "sendleID:APIKey"
   -H "Content-Type: application/json"
+  -H "Accept: application/json"
 ```
 
 > 200 Response

--- a/source/includes/_cancelling_orders.md
+++ b/source/includes/_cancelling_orders.md
@@ -5,7 +5,7 @@
 ```shell
   curl "https://www.sendle.com/api/orders/f5233746-71d4-4b05-bf63-56f4abaed5f6"
   -X DELETE
-  -u "sendleAPI:42RRTjYz5Z4hZrm8XY3t4Vxt"
+  -u "sendleID:APIKey"
   -H "Content-Type: application/json"
 ```
 

--- a/source/includes/_create_orders.md
+++ b/source/includes/_create_orders.md
@@ -13,6 +13,7 @@ To create an order, submit order data via POST command. The order will be reject
   -X POST
   -u "sendleID:APIKey"
   -H "Content-Type: application/json"
+  -H "Accept: application/json"
   -d '{
     "pickup_date": "2015-11-24",
     "description": "Kryptonite",

--- a/source/includes/_create_orders.md
+++ b/source/includes/_create_orders.md
@@ -11,7 +11,7 @@ To create an order, submit order data via POST command. The order will be reject
 ```shell
   curl "https://www.sendle.com/api/orders"
   -X POST
-  -u "sendleAPI:42RRTjYz5Z4hZrm8XY3t4Vxt"
+  -u "sendleID:APIKey"
   -H "Content-Type: application/json"
   -d '{
     "pickup_date": "2015-11-24",

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -14,10 +14,8 @@ Error Code | Meaning
 [402](#402-payment-required) | **Payment Required** -- The client does not yet have a payment-method set up on their account, and cannot create orders.
 [404](#404-not-found) | **Not Found** -- The requested resource/URI was not found.
 [422](#422-unprocessable-entity) | **Unprocessable Entity** -- The server was unable to complete the request due to the data itself. For example, validations within the data may fail, or an upstream request may not be able to be fulfilled with the data. This is different to `400 Bad Request` as `422 Unprocessable Entity` suggests that the request sent by the client was structurally valid, and the request was attempted.
-[500] **Internal Error** -- an unhandled error has occured with the
-Sendle API. Contact support@sendle.com if the problem persists.
-[503](#503-not-available) **Not Available** -- The server is currently
-unavailable, due to maintenance or upgrades.
+500 | **Internal Error** -- an unhandled error has occured with the Sendle API. Contact <a href="mailto:support@sendle.com">support@sendle.com</a> if the problem persists.
+[503](#503-not-available) | **Not Available** -- The server is currently unavailable, due to maintenance or upgrades.
 
 ## 400 Bad request
 

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -14,9 +14,8 @@ Error Code | Meaning
 [402](#402-payment-required) | **Payment Required** -- The client does not yet have a payment-method set up on their account, and cannot create orders.
 [404](#404-not-found) | **Not Found** -- The requested resource/URI was not found.
 [422](#422-unprocessable-entity) | **Unprocessable Entity** -- The server was unable to complete the request due to the data itself. For example, validations within the data may fail, or an upstream request may not be able to be fulfilled with the data. This is different to `400 Bad Request` as `422 Unprocessable Entity` suggests that the request sent by the client was structurally valid, and the request was attempted.
-[500](#500-internal-server-error) | **Internal Server Error** -- An error occurred within the system itself. This may be a coding error that caused the system to fail. The development team will have been notified of this failure.
-[503](#503-internal-server-error) | **Service Unavailable** -- An error occurred within the system due to an upstream error or failure. For example, a courier API may be unavailable or failing to respond.  The development team will have been notified of this failure.
-
+[503](#503-not-available) **Not Available** -- The server is currently
+unavailable, due to maintenance or upgrades.
 
 ## 400 Bad request
 
@@ -31,19 +30,11 @@ Error Code | Meaning
 
 ```
   HTTP/1.1 400 Bad Request
-  Server: Cowboy
-  Date: Mon, 19 Oct 2015 04:37:32 GMT
-  Connection: keep-alive
   Content-Type: text/html; charset=utf-8
-  X-Request-Id: ca3d8539-acfa-4f9a-b3d7-416f32f31393
-  X-Runtime: 0.032672
-  Vary: Accept-Encoding
-  Strict-Transport-Security: max-age=31536000
   Content-Length: 0
-  Via: 1.1 vegur
 ```
 
-*Invalid API request formatting*
+*Invalid request format*
 
 When an invalid request is sent to the API, there is no visible response. This will include mostly formatting errors.
 
@@ -205,26 +196,14 @@ Without accepting [dangerous goods terms](#set-up-account), booking orders will 
     "error":"unprocessable_entity",
     "error_description":"The data you supplied is invalid. Error messages are in the messages section. Please fix those fields and try again."
 ```
+*Data format was correct but contained unprocessable information*
 
-*Data could not be processed, but API format is correct*
-
-`422` errors occur most commonly as users become more familiar with the API interface. These errors occur when the server receives your request, it is properly formatted, but the POST information can not be processed as is.
+`422` errors occur most commonly as users become more familiar with the API interface. These errors occur when the server receives your request, it is properly formatted, but the information can not be processed as is.
 
 Be sure to check the error messages as the server response will explain why the request could not be processed and often give suggestions.
 
+## 503 Not Available
 
-## 500 Internal Server Error
-
-```
-  500 Internal Server Error
-  If you are the administrator of this website, then please read this web application's log file and/or the web server's log file to find out what went wrong.
-```
-
-*Invalid Endpoint*
-
-As an example, sending a request to `https://sendle.com/api/` will yield a `500` error because the url endpoint is invalid. If you send requests at a valid endpoint like `https://sendle.com/api/quote/` and receive a `500` error there is a server-side problem, Sendle will address the problem as soon as possible.
-
-
-## 503 Internal Server Error
-
-An error occurred within the system due to an upstream error or failure. For example, a courier API may be unavailable or failing to respond. The development team will have been notified of this failure.
+From time to time we might require a short outage to carry out
+maintenance or upgrades. In most cases the API will return a HTTP 503
+error response.

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -14,6 +14,8 @@ Error Code | Meaning
 [402](#402-payment-required) | **Payment Required** -- The client does not yet have a payment-method set up on their account, and cannot create orders.
 [404](#404-not-found) | **Not Found** -- The requested resource/URI was not found.
 [422](#422-unprocessable-entity) | **Unprocessable Entity** -- The server was unable to complete the request due to the data itself. For example, validations within the data may fail, or an upstream request may not be able to be fulfilled with the data. This is different to `400 Bad Request` as `422 Unprocessable Entity` suggests that the request sent by the client was structurally valid, and the request was attempted.
+[500] **Internal Error** -- an unhandled error has occured with the
+Sendle API. Contact support@sendle.com if the problem persists.
 [503](#503-not-available) **Not Available** -- The server is currently
 unavailable, due to maintenance or upgrades.
 

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -23,8 +23,8 @@ Error Code | Meaning
 ```shell
   curl -i "https://www.sendle.com/api/orders"
   -X POST
-  -u "sendleAPI:42RRTjYz5Z4hZrm8XY3t4Vxt"
-  -H "Content-Type: application/json" 
+  -u "sendleID:APIKey"
+  -H "Content-Type: application/json"
   -d ']'
 ```
 > 400 Response Header information:
@@ -124,7 +124,7 @@ Without accepting [dangerous goods terms](#set-up-account), booking orders will 
 
 ```shell
   curl "https://www.sendle.com/api/orders"
-  -u "sendleAPI:42RRTjYz5Z4hZrm8XY3t4Vxt"
+  -u "sendleID:APIKey"
   -H "Content-Type: application/json"
   -X POST
   -d '{

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -14,7 +14,7 @@ Error Code | Meaning
 [402](#402-payment-required) | **Payment Required** -- The client does not yet have a payment-method set up on their account, and cannot create orders.
 [404](#404-not-found) | **Not Found** -- The requested resource/URI was not found.
 [422](#422-unprocessable-entity) | **Unprocessable Entity** -- The server was unable to complete the request due to the data itself. For example, validations within the data may fail, or an upstream request may not be able to be fulfilled with the data. This is different to `400 Bad Request` as `422 Unprocessable Entity` suggests that the request sent by the client was structurally valid, and the request was attempted.
-500 | **Internal Error** -- an unhandled error has occured with the Sendle API. Contact <a href="mailto:support@sendle.com">support@sendle.com</a> if the problem persists.
+500 | **Internal Error** -- An unhandled error has occured with the Sendle API. Contact <a href="mailto:support@sendle.com">support@sendle.com</a> if the problem persists.
 [503](#503-not-available) | **Not Available** -- The server is currently unavailable, due to maintenance or upgrades.
 
 ## 400 Bad request

--- a/source/includes/_getting_labels.md
+++ b/source/includes/_getting_labels.md
@@ -5,7 +5,7 @@
 
 ```shell
   curl "https://www.sendle.com/api/orders/f5233746-71d4-4b05-bf63-56f4abaed5f6/labels/a4.pdf"
-  -u "sendleAPI:42RRTjYz5Z4hZrm8XY3t4Vxt"
+  -u "sendleID:APIKey"
   -o "label.pdf"
 ```
 

--- a/source/includes/_getting_quotes.md
+++ b/source/includes/_getting_quotes.md
@@ -10,7 +10,7 @@ The quoting API does not require you to include your Sendle ID and API Key, but 
 > [GET /api/quote]
 
 ```shell
-  curl 'https://www.sendle.com/api/quote?pickup_suburb=Wonglepong&pickup_postcode=4275&delivery_suburb=Foul%20Bay&delivery_postcode=5577&kilogram_weight=2.0&cubic_metre_volume=0.01' -H 'Content-Type: application/json'
+  curl 'https://www.sendle.com/api/quote?pickup_suburb=Wonglepong&pickup_postcode=4275&delivery_suburb=Foul%20Bay&delivery_postcode=5577&kilogram_weight=2.0&cubic_metre_volume=0.01' -H 'Content-Type: application/json' -H 'Accept: application/json'
 ```
 
 > 200 Response

--- a/source/includes/_getting_started.md
+++ b/source/includes/_getting_started.md
@@ -19,6 +19,10 @@ With Access granted, visit `Account Settings` by clicking the account's email in
 
 Once you have been granted API access, visit your API tab to get your `api key`.
 
+Requests to the API require the use of HTTP Basic Authentication using
+your account's Sendle ID as the user name and your API key as the
+password.
+
 <aside class="warning">Consider your API Key as a password. Be sure to keep your API Key private!</aside>
 
 ## Set Up Payments

--- a/source/includes/_getting_started.md
+++ b/source/includes/_getting_started.md
@@ -13,7 +13,7 @@ Before anything else, you will need to have a [Sendle Account](https://www.sendl
 
 ![Account Settings](images/account_settings.png)
 
-With Access granted, visit `Account Settings`  in the drop down next to your Sendle ID_(top right)_ on your Sendle Dashboard.
+With Access granted, visit `Account Settings` by clicking the account's email in the top right corner and selecting `Account Settings` from the drop down.
 
 ![API Modal](images/api_modal.png)
 

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -11,7 +11,7 @@
 
 You can use our API to book Sendle parcels, manage shipping, and oversee past and present orders any way you like!
 
-Sendle API uses [JSON](http://www.json.org/). You can view code examples in the dark area to the right.
+Sendle API uses [JSON](http://www.json.org/). You can view code examples in the rightmost column.
 
 For all examples in this guide, we will be using [**cURL**](http://curl.haxx.se/) from the command line, but you are encouraged to make requests in whichever method you are most comfortable with.
 

--- a/source/includes/_ping_server.md
+++ b/source/includes/_ping_server.md
@@ -3,11 +3,11 @@
 
 > [ GET /api/ping ]
 
-> All API interactions will require your Sendle ID and your API Key (Make sure to replace **sendleAPI** and **42RRTjYz5Z4hZrm8XY3t4Vxt** with your Sendle ID & API key.)
+> All API interactions will require your Sendle ID and your API Key as username and password for HTTP Basic Authentication (Make sure to replace **sendleID** and **APIKey** with your Sendle ID & API key.)
 
 ```shell
   curl 'https://www.sendle.com/api/ping'
-  -u sendleAPI:42RRTjYz5Z4hZrm8XY3t4Vxt
+  -u sendleID:APIKey
 ```
 
 Sendle uses your **Sendle ID** together with your own **API Key** to grant access to the server. Together this allows you to access the API so that you may book and follow up with orders, as well as view past orders you have sent or received.
@@ -49,7 +49,5 @@ When the api receives a request with a `Sendle ID` and an `API Key` the server r
     "error_description":"The authorisation details are not valid. Either the Sendle ID or API key are incorrect."
   }
 ```
-
-If you include your `Sendle ID` without your `API Key`, the server will ask for your `API Key` (as **password** if using cURL). If you reply with your key the server will respond with the original request, but as API keys are long and complex, this is not ideal practice.
 
 <aside class='warning'>Errors are covered in detail in the <a href="#errors">Errors</a> Section (see sidebar)</aside>

--- a/source/includes/_ping_server.md
+++ b/source/includes/_ping_server.md
@@ -8,6 +8,8 @@
 ```shell
   curl 'https://www.sendle.com/api/ping'
   -u sendleID:APIKey
+  -H "Content-Type: application/json"
+  -H "Accept: application/json"
 ```
 
 Sendle uses your **Sendle ID** together with your own **API Key** to grant access to the server. Together this allows you to access the API so that you may book and follow up with orders, as well as view past orders you have sent or received.

--- a/source/includes/_view_order.md
+++ b/source/includes/_view_order.md
@@ -5,7 +5,7 @@
 
 ```shell
   curl "https://www.sendle.com/api/orders/f5233746-71d4-4b05-bf63-56f4abaed5f6"
-    -u "sendleAPI:42RRTjYz5Z4hZrm8XY3t4Vxt"
+    -u "sendleID:APIKey"
     -H "Content-Type: application/json"
 ```
 


### PR DESCRIPTION
Replace specific Sendle ID and API key in doco with more obvious placeholder

Corrected description of 500 errors

Made use of HTTP auth explicit rather than implied via the cURL `-u` usage